### PR TITLE
Fix: Restore profile picture on main page

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -15,6 +15,9 @@ layout: default
 {% endif %}
 
 <div id="main" role="main">
+  {% if page.author_profile %}
+    {% include author-profile.html %}
+  {% endif %}
   <article class="page" itemscope itemtype="http://schema.org/CreativeWork">
     {% if page.title %}<meta itemprop="headline" content="{{ page.title | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -72,3 +72,42 @@ a {
     background-color: darken($primary-color, 10%);
   }
 }
+
+// Author profile
+.author__avatar {
+  display: block;
+  margin: 0 auto 1em;
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+}
+
+.author__content {
+  text-align: center;
+}
+
+.author__name {
+  margin-bottom: 0.5em;
+}
+
+.author__bio {
+  margin-bottom: 1em;
+}
+
+.author__urls-wrapper {
+  text-align: center;
+  margin-bottom: 2em;
+
+  .btn--inverse {
+    display: none; // Hide the follow button
+  }
+}
+
+.author__urls {
+  list-style: none;
+  padding: 0;
+  display: inline-flex;
+  gap: 1em;
+  justify-content: center;
+  flex-wrap: wrap;
+}


### PR DESCRIPTION
The profile picture was unintentionally removed during the redesign. This commit restores the author profile, including the profile picture, to the main page. It also adds styling to ensure the profile is displayed correctly within the new single-column layout.